### PR TITLE
Corrected the name of the handlebar ghost_foot.

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -67,7 +67,7 @@
     </footer>
 
     {{! Ghost outputs important scripts and data with this tag }}
-    {{ghost_foo }}
+    {{ghost_foot}}
 
     <script type="text/javascript" src="{{asset "js/scripts.min.js"}}"></script>
 			


### PR DESCRIPTION
By correcting the name of the handlebar ghost_foot users will be able to do code injections in Ghost Admin Blog Footer.

Example below:
![Uploading ghost_code_injection.PNG…]()
